### PR TITLE
Remove Abbreviated Type Information From Property Name

### DIFF
--- a/src/TechBuddy.Middlewares.RequestResponse/Infrastructure/MessageCreators/BaseLogMessageCreator.cs
+++ b/src/TechBuddy.Middlewares.RequestResponse/Infrastructure/MessageCreators/BaseLogMessageCreator.cs
@@ -11,7 +11,7 @@
                 LogFields.QueryString => requestResponseContext.Context?.Request?.QueryString.Value,
                 LogFields.Path => requestResponseContext.Context?.Request?.Path.Value,
                 LogFields.HostName => requestResponseContext.Context?.Request?.Host.Value,
-                LogFields.ResponseTiming => requestResponseContext.ResponseTimeStr,
+                LogFields.ResponseTiming => requestResponseContext.ResponseTime,
                 LogFields.RequestLength => requestResponseContext.RequestLength.ToString(),
                 LogFields.ResponseLength => requestResponseContext.ResponseLength.ToString(),
                 _ => string.Empty

--- a/src/TechBuddy.Middlewares.RequestResponse/Models/RequestResponseContext.cs
+++ b/src/TechBuddy.Middlewares.RequestResponse/Models/RequestResponseContext.cs
@@ -23,7 +23,7 @@ namespace TechBuddy.Middlewares.RequestResponse
         /// <summary>
         /// Gets total response duration. Format: mm:ss.fff
         /// </summary>
-        public string ResponseTimeStr => ResponseCreationTime is null ? "" : string.Format("{0:mm\\:ss\\.fff}", ResponseCreationTime);
+        public string ResponseTime => ResponseCreationTime is null ? "" : string.Format("{0:mm\\:ss\\.fff}", ResponseCreationTime);
 
 
         public int? RequestLength => RequestBody?.Length == 0 ? null : RequestBody.Length;

--- a/src/TechBuddy.Middlewares.RequestResponse/README.md
+++ b/src/TechBuddy.Middlewares.RequestResponse/README.md
@@ -35,7 +35,7 @@ app.AddTBRequestResponseMiddleware(opt =>
         var resLength = context.ResponseLength;
 
         var responseTimeSpan = context.ResponseCreationTime;
-        var responseFormattedTimeSpan = context.ResponseTimeStr;
+        var responseFormattedTimeSpan = context.ResponseTime;
         
         //Console.Write(System.Text.Json.JsonSerializer.Serialize(context));
     });


### PR DESCRIPTION
It looks better if the ResponseTime property of RequestResponseContext does not have the added abbreviated type information.
I think it's easy enough to see that its type is String.